### PR TITLE
Swift 2.2 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
 os: osx
-osx_image: xcode7.2
+osx_image: xcode7.3
 
 script: set -o pipefail && xcodebuild -scheme 'Rainbow(OSX)' clean test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
 after_success:

--- a/Sources/CodesParser.swift
+++ b/Sources/CodesParser.swift
@@ -25,7 +25,7 @@
 //  THE SOFTWARE.
 
 protocol CodesParser {
-    typealias SourceType
+    associatedtype SourceType
     func parseModeCodes(codes: [SourceType]) ->
         (color: Color?, backgroundColor: BackgroundColor?, styles: [Style]?)
 }

--- a/Sources/ModesExtractor.swift
+++ b/Sources/ModesExtractor.swift
@@ -25,7 +25,7 @@
 //  THE SOFTWARE.
 
 protocol ModesExtractor {
-    typealias ResultType
+    associatedtype ResultType
     func extractModeCodes(string: String) -> (codes: [ResultType], text: String)
 }
 


### PR DESCRIPTION
`typealias` in protocols changed to `associatedtype`.