### PR TITLE
Added swiftenv to '.travis.yml' to recognize content of '.swift-version'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
-language: objective-c
+language: swift
 os: osx
 osx_image: xcode9
 
-script: set -o pipefail && xcodebuild -scheme 'Rainbow(OSX)' clean test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
+install:
+- eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+
+script:
+- set -o pipefail && xcodebuild -scheme 'Rainbow(OSX)' clean test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty
+
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+- bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Without using either **swiftenv** or **cocoapods** `.swift-version` doesn't appear to be recognized.

> ## Travis CI
> You can use **swiftenv** to both install Swift, and to manage multiple versions of Swift on Travis CI.
> 
> Using the following install phase, you can install both **swiftenv** and the Swift version found in the .swift-version file or the `SWIFT_VERSION` environment variable.
> 
> ```
> install:
>   - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
> ```
https://swiftenv.fuller.li/en/latest/integrations/travis-ci.html
