### PR TITLE
Pick the right slicing overload

### DIFF
--- a/Sources/ModesExtractor.swift
+++ b/Sources/ModesExtractor.swift
@@ -44,7 +44,7 @@ struct ConsoleModesExtractor: ModesExtractor {
         let codes = codesString.split(separator: ";", maxSplits: Int.max, omittingEmptySubsequences: false).flatMap { UInt8(String($0)) }
         let startIndex = string.index(after: index)
         let endIndex = string.index(string.endIndex, offsetBy: -"\(token)0m".count)
-        let text = String(string[startIndex ..< endIndex])
+        let text = String(string[startIndex ..< endIndex] as Substring)
         
         return (codes, text)
     }
@@ -75,7 +75,7 @@ struct XcodeColorsModesExtractor: ModesExtractor {
         
         let startIndex = index
         let endIndex = string.index(string.endIndex, offsetBy: -"\(token);".count)
-        let text = String(string[startIndex ..< endIndex])
+        let text = String(string[startIndex ..< endIndex] as Substring)
         
         return (codes, text)
     }


### PR DESCRIPTION
Fixes the package build and #21 

The Xcode project is building with the 4.0 tools, but the package
itself is still using the Swift 3.0 package layout and tools.  This
means that the compiler does not see the availability annotations that
suppress the `init?(_ other: String)` overload causing mismatched optionality to
occur if you build the package with SwiftPM but not with Xcode.  Because
it would be more invasive to re-layout the package for Swift 4.0, I'm
just going to force it to pick the right overload with a cast.