### PR TITLE
Improved Swift Manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,15 @@
 // swift-tools-version:4.0
 
 import PackageDescription
+
 let package = Package(
     name: "Rainbow",
+    products: [
+        .library(name: "Rainbow", targets: ["Rainbow"]),
+    ],
+    dependencies: [],
     targets: [
-        .target(name: "Rainbow", path: "Sources"),
-        .testTarget(name: "RainbowTests", dependencies: ["Rainbow"], path: "Tests")
+        .target(name: "Rainbow", dependencies: [], path: "Sources"),
+        .testTarget(name: "RainbowTests", dependencies: ["Rainbow"], path: "Tests"),
     ]
 )


### PR DESCRIPTION
A Swift manifest needs to declare `products: […]` in order to make the package accessible from other packages.