### PR TITLE
Use Glibc under Cygwin

### DIFF
--- a/Sources/OutputTarget.swift
+++ b/Sources/OutputTarget.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(Linux)
+#if os(Linux) || CYGWIN
 import Glibc
 #else
 import Darwin.C


### PR DESCRIPTION
I've added logic to treat a Cygwin install as Linux rather than as a Mac.


See https://github.com/apple/swift-corelibs-foundation/pull/381 for why CYGWIN is used instead of os(Cygwin).