### PR TITLE
Use `removeAll` for Swift 5 and O(n) filter for Swift < 4.2

### DIFF
--- a/Sources/String+Rainbow.swift
+++ b/Sources/String+Rainbow.swift
@@ -104,17 +104,12 @@ extension String {
         }
         
         let current = Rainbow.extractModes(for: self)
-        if let styles = current.styles {
-            var s = styles
-            var index = s.index(of: style)
-            while index != nil {
-                s.remove(at: index!)
-                index = s.index(of: style)
-            }
+        if var styles = current.styles {
+            styles.removeAll { $0 == style }
             return Rainbow.generateString(
                 forColor: current.color,
                 backgroundColor: current.backgroundColor,
-                styles: s,
+                styles: styles,
                 text: current.text
             )
         } else {

--- a/Sources/String+Rainbow.swift
+++ b/Sources/String+Rainbow.swift
@@ -105,7 +105,11 @@ extension String {
         
         let current = Rainbow.extractModes(for: self)
         if var styles = current.styles {
+            #if swift(>=4.2)
             styles.removeAll { $0 == style }
+            #else
+            styles = styles.filter { $0 != style }
+            #endif
             return Rainbow.generateString(
                 forColor: current.color,
                 backgroundColor: current.backgroundColor,


### PR DESCRIPTION
Although `index(of:)` has been renamed to `firstIndex(of:)` in Swift 5, `removeAll` should work for Swift 5 and previous versions of Swift as well.