### PR TITLE
Add support for NO_COLOR env variable

### DIFF
--- a/Sources/Rainbow.swift
+++ b/Sources/Rainbow.swift
@@ -43,7 +43,7 @@ public struct Rainbow {
     /// However, if you want the colorized string to be different, or the detection is not correct, you can set it manually.
     public static var outputTarget = OutputTarget.current
     
-    /// Enable `Rainbow` to colorize string or not. Default is `true`.
+    /// Enable `Rainbow` to colorize string or not. Default is `true`, unless the `NO_COLOR` environment variable is set.
     public static var enabled = ProcessInfo.processInfo.environment["NO_COLOR"] == nil
     
     public static func extractModes(for string: String)

--- a/Sources/Rainbow.swift
+++ b/Sources/Rainbow.swift
@@ -44,7 +44,7 @@ public struct Rainbow {
     public static var outputTarget = OutputTarget.current
     
     /// Enable `Rainbow` to colorize string or not. Default is `true`.
-    public static var enabled = true
+    public static var enabled = ProcessInfo.processInfo.environment["NO_COLOR"] == nil
     
     public static func extractModes(for string: String)
         -> (color: Color?, backgroundColor: BackgroundColor?, styles: [Style]?, text: String)


### PR DESCRIPTION
See https://no-color.org/. This is also supported by e.g. Homebrew, npm, and various console output libraries for other languages.