### PR TITLE
Update to use case-less enum as a pure namespace for constants

### DIFF
--- a/Sources/ControlCode.swift
+++ b/Sources/ControlCode.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-struct ControlCode {
+enum ControlCode {
     static let ESC = "\u{001B}"
     static let CSI = "\(ESC)["
 }

--- a/Sources/Rainbow.swift
+++ b/Sources/Rainbow.swift
@@ -37,7 +37,7 @@ public protocol ModeCode {
 /**
  Setting for `Rainbow`.
  */
-public struct Rainbow {
+public enum Rainbow {
     
     /// Output target for `Rainbow`. `Rainbow` should detect correct target itself, so you rarely need to set it. 
     /// However, if you want the colorized string to be different, or the detection is not correct, you can set it manually.


### PR DESCRIPTION
See the note here: https://github.com/raywenderlich/swift-style-guide#constants.

> The advantage of using a case-less enumeration is that it can't accidentally be instantiated and works as a pure namespace.