### PR TITLE
Add strikethrough style support

### DIFF
--- a/Playground/main.swift
+++ b/Playground/main.swift
@@ -41,3 +41,27 @@ let entry = Rainbow.Entry(
     ]
 )
 print(Rainbow.generateString(for: entry))
+
+print("")
+
+// Strikethrough examples
+print("=== Strikethrough Style Examples ===".bold)
+print("This is \("deleted text".strikethrough)")
+print("Error: \("Deprecated method".red.strikethrough) - use new API instead")
+print("\("Old price: $99.99".strikethrough) \("New price: $79.99".green.bold)")
+print("")
+print("Combining with other styles:")
+print("  • \("Strikethrough + Bold".strikethrough.bold)")
+print("  • \("Strikethrough + Italic".strikethrough.italic)")
+print("  • \("Strikethrough + Underline".strikethrough.underline)")
+print("  • \("Strikethrough + Red + Bold".red.strikethrough.bold)")
+print("")
+print("Complex example:")
+let todoList = """
+TODO List:
+  ✓ \("Setup project".strikethrough.dim)
+  ✓ \("Write tests".strikethrough.dim)
+  - Implement feature
+  - Code review
+"""
+print(todoList)

--- a/Sources/String+Rainbow.swift
+++ b/Sources/String+Rainbow.swift
@@ -394,6 +394,8 @@ extension String {
     public var blink: String { return applyingStyle(.blink) }
     /// String with text color and background color swapped.
     public var swap: String { return applyingStyle(.swap) }
+    /// String with strikethrough style.
+    public var strikethrough: String { return applyingStyle(.strikethrough) }
 }
 
 // MARK: - Clear Modes Shorthand

--- a/Tests/RainbowTests/ConsoleStringTests.swift
+++ b/Tests/RainbowTests/ConsoleStringTests.swift
@@ -105,6 +105,7 @@ class ConsoleStringTests: XCTestCase {
         XCTAssertEqual(string.underline, "\u{001B}[4mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.blink, "\u{001B}[5mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.swap, "\u{001B}[7mHello Rainbow\u{001B}[0m")
+        XCTAssertEqual(string.strikethrough, "\u{001B}[9mHello Rainbow\u{001B}[0m")
     }
     
     func testStringMultipleModes() {
@@ -115,6 +116,9 @@ class ConsoleStringTests: XCTestCase {
         XCTAssertEqual(string.onWhite.dim.blink, "\u{001B}[47;2;5mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.red.blue.onWhite, "\u{001B}[34;47mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.red.blue.green.blue.blue, "\u{001B}[34mHello Rainbow\u{001B}[0m")
+        XCTAssertEqual(string.red.strikethrough, "\u{001B}[31;9mHello Rainbow\u{001B}[0m")
+        XCTAssertEqual(string.strikethrough.underline, "\u{001B}[9;4mHello Rainbow\u{001B}[0m")
+        XCTAssertEqual(string.red.onYellow.strikethrough, "\u{001B}[31;43;9mHello Rainbow\u{001B}[0m")
     }
     
     func testStringClearMode() {
@@ -128,6 +132,8 @@ class ConsoleStringTests: XCTestCase {
         XCTAssertEqual(string.red.clearStyles, "\u{001B}[31mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.red.bold.clearStyles, "\u{001B}[31mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.red.bold.clearColor, "\u{001B}[1mHello Rainbow\u{001B}[0m")
+        XCTAssertEqual(string.strikethrough.clearStyles, "Hello Rainbow")
+        XCTAssertEqual(string.red.strikethrough.clearStyles, "\u{001B}[31mHello Rainbow\u{001B}[0m")
         XCTAssertEqual(string.bold.italic.clearStyles, "Hello Rainbow")
     }
 


### PR DESCRIPTION
## Summary
- Implemented strikethrough style support for Rainbow library
- Added comprehensive test coverage for the new strikethrough feature
- Updated Playground with strikethrough examples

## Changes
1. **String+Rainbow.swift**: Added `strikethrough` computed property that applies ANSI code 9 for strikethrough text styling
2. **ConsoleStringTests.swift**: Added comprehensive tests including:
   - Basic strikethrough functionality
   - Strikethrough combined with colors
   - Strikethrough in style chains
   - Raw string extraction with strikethrough
3. **Playground**: Added examples demonstrating strikethrough usage both standalone and combined with other styles

## Test Plan
All tests pass successfully. The strikethrough style has been tested:
- [x] As a standalone style
- [x] Combined with foreground colors
- [x] Combined with background colors
- [x] In complex style chains
- [x] With raw string extraction