### PR TITLE
Enable console output target on Windows by default

### DIFF
--- a/Sources/OutputTarget.swift
+++ b/Sources/OutputTarget.swift
@@ -44,6 +44,10 @@ public enum OutputTarget {
     
     /// Detected output target by current environment.
     static var current: OutputTarget = {
+        #if os(Windows)
+        // Windows terminals generally support ANSI escape codes in modern versions
+        return .console
+        #else
         // Check if we are in any term env and the output is a tty.
         let termType = getEnvValue("TERM")
         if let t = termType, t.lowercased() != "dumb" && isatty(fileno(stdout)) != 0 {
@@ -51,5 +55,6 @@ public enum OutputTarget {
         }
         
         return .unknown
+        #endif
     }()
 }

--- a/Sources/OutputTarget.swift
+++ b/Sources/OutputTarget.swift
@@ -45,8 +45,12 @@ public enum OutputTarget {
     /// Detected output target by current environment.
     static var current: OutputTarget = {
         #if os(Windows)
-        // Windows terminals generally support ANSI escape codes in modern versions
-        return .console
+        // Windows terminals support ANSI escape codes in modern versions (Windows 10+)
+        // Use _isatty to check if stdout is connected to a terminal
+        if _isatty(_fileno(stdout)) != 0 {
+            return .console
+        }
+        return .unknown
         #else
         // Check if we are in any term env and the output is a tty.
         let termType = getEnvValue("TERM")


### PR DESCRIPTION
Fixes #87 

Modern Windows terminals (Windows 10+, Windows Terminal, PowerShell) support ANSI escape codes. This change enables colored output by default on Windows by returning `.console` as the detected output target.

## Changes

- Added `#if os(Windows)` conditional compilation to return `.console` directly on Windows
- Keeps existing TTY detection behavior on other platforms