### PR TITLE
Add Windows CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build
       run: swift build -v
     - name: Run tests
@@ -19,7 +19,19 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Swift
+      uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 # v1.14.0
+      with:
+        swift-version: latest
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build
       run: swift build -v
     - name: Run tests
@@ -19,7 +19,7 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build
       run: swift build -v
     - name: Run tests
@@ -27,7 +27,7 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Setup Swift
       uses: SwiftyLab/setup-swift@38f54a76b70d989321de9dc7c840618c08cf56e9 # v1.14.0
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,4 +35,4 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: swift test -v
+      run: swift test -v --enable-test-discovery


### PR DESCRIPTION
## What changed

- Add a `windows-latest` job that installs the latest Swift toolchain and runs `swift build` and `swift test`.
- Update existing checkout steps from `actions/checkout@v2` to `actions/checkout@v6`.

## Why

Windows-specific code is currently excluded from the Linux and macOS builds, so regressions such as missing platform imports cannot be detected before merge. A native Windows job gives those code paths real build and test coverage.

The setup action is pinned to the commit for v1.14.0 to avoid executing a moving third-party tag.

## Validation

- `actionlint .github/workflows/ci.yaml`
- `git diff --check`